### PR TITLE
Quick hack to specify the macros file

### DIFF
--- a/lib/macros_autocompletion/macro_completer.js
+++ b/lib/macros_autocompletion/macro_completer.js
@@ -23,7 +23,18 @@ const provider = {
 
         const [prefix, macro_name_prefix, obrace] = prefix_match
 
-        const matching_macros = find_macros(lu.strip_comments(request.editor.getBuffer().getText()), escape_regex(macro_name_prefix))
+        var text = request.editor.getBuffer().getText() //By default we take macros from the current buffer
+        var match
+        var macrosFile
+        var texRootRex = /%(\s+)?!TEX macros(\s+)?=(\s+)?(.+)/g // Comment including the *absolute* path to the macros file
+        while(match = texRootRex.exec(request.editor.getBuffer().getText())) {
+          macrosFile = match[4]
+        }
+        if (macrosFile != undefined) { // If there was no file specified it works as before
+          text = fs.readFileSync(macrosFile, 'utf-8');
+        }
+        const matching_macros = find_macros(lu.strip_comments(text), escape_regex(macro_name_prefix))
+
         if (!matching_macros){
             return null
         }


### PR DESCRIPTION
This is just a quick hack to be able to be able to get autocompletion from macros specified in a different file. It just looks for a comment of the form %!TEX macros = <absolute path to the macros file>. It is quite rudimentary that's why it requires the absolute path.