### PR TITLE
Specify macros file

### DIFF
--- a/lib/macros_autocompletion/macro_completer.js
+++ b/lib/macros_autocompletion/macro_completer.js
@@ -1,5 +1,5 @@
 "use strict"
-
+var fs = require('fs')
 const lu = require('../utilities/latex_utilities')
 const escape_regex = require('escape-regexp')
 
@@ -26,12 +26,20 @@ const provider = {
         var text = request.editor.getBuffer().getText() //By default we take macros from the current buffer
         var match
         var macrosFile
-        var texRootRex = /%(\s+)?!TEX macros(\s+)?=(\s+)?(.+)/g // Comment including the *absolute* path to the macros file
+        var texRootRex = /%(\s+)?!TEX macros(\s+)?=(\s+)?(.+)/g // Comment including the relative path to the macros file
+        var editor = atom.workspace.getActivePaneItem()
+        var file = editor.buffer.file
+        var path = file.path
+
         while(match = texRootRex.exec(request.editor.getBuffer().getText())) {
-          macrosFile = match[4]
+          macrosFile = absolute(path,match[4])
         }
-        if (macrosFile != undefined) { // If there was no file specified it works as before
-          text = fs.readFileSync(macrosFile, 'utf-8');
+        if (macrosFile != undefined) {
+          try {
+            text = fs.readFileSync(macrosFile, 'utf-8');
+          } catch (e) {
+            atom.notifications.addError('Macros file not found. Please, check the specified path.')
+          }
         }
         const matching_macros = find_macros(lu.strip_comments(text), escape_regex(macro_name_prefix))
 
@@ -93,6 +101,24 @@ const snippet_from_macro_desc = function(macro_desc){
     // Due to [snippet idiosyncrasies](https://github.com/atom/snippets/issues/127),
     // don't forget to double our backslashes.
     return snippet.replace('\\', '\\\\')
+}
+
+// Simple function to compute the absolute path from the relative one and the
+// base
+function absolute(base, relative) {
+  var stack = base.split("/"),
+      parts = relative.split("/");
+  stack.pop(); // remove current file name (or empty string)
+  // (omit if "base" is the current folder without trailing slash)
+  for (var i=0; i<parts.length; i++) {
+    if (parts[i] == ".")
+    continue;
+    if (parts[i] == "..")
+    stack.pop();
+    else
+    stack.push(parts[i]);
+  }
+  return stack.join("/");
 }
 
 module.exports = {

--- a/lib/macros_autocompletion/macro_completer.js
+++ b/lib/macros_autocompletion/macro_completer.js
@@ -3,7 +3,7 @@ const lu = require('../utilities/latex_utilities')
 const escape_regex = require('escape-regexp')
 
 const fs = require('fs')
-const path = require('path');
+const path = require('path')
 
 const provider = {
     selector: '.text.tex.latex',

--- a/lib/macros_autocompletion/macro_completer.js
+++ b/lib/macros_autocompletion/macro_completer.js
@@ -23,7 +23,18 @@ const provider = {
 
         const [prefix, macro_name_prefix, obrace] = prefix_match
 
-        const matching_macros = find_macros(lu.strip_comments(request.editor.getBuffer().getText()), escape_regex(macro_name_prefix))
+        var text = request.editor.getBuffer().getText() //By default we take macros from the current buffer
+        var match
+        var macrosFile
+        var texRootRex = /%(\s+)?!TEX macros(\s+)?=(\s+)?(.+)/g // Comment including the *absolute* path to the macros file
+        while(match = texRootRex.exec(request.editor.getBuffer().getText())) {
+          macrosFile = match[4]
+        }
+        if (macrosFile != undefined) { // If there was no file specified it works as before
+          text = fs.readFileSync(macrosFile, 'utf-8');
+        }
+        const matching_macros = find_macros(lu.strip_comments(text), escape_regex(macro_name_prefix))
+
         if (!matching_macros){
             return null
         }

--- a/lib/macros_autocompletion/macro_completer.js
+++ b/lib/macros_autocompletion/macro_completer.js
@@ -1,7 +1,9 @@
 "use strict"
-var fs = require('fs')
 const lu = require('../utilities/latex_utilities')
 const escape_regex = require('escape-regexp')
+
+const fs = require('fs')
+const path = require('path');
 
 const provider = {
     selector: '.text.tex.latex',
@@ -23,25 +25,29 @@ const provider = {
 
         const [prefix, macro_name_prefix, obrace] = prefix_match
 
-        var text = request.editor.getBuffer().getText() //By default we take macros from the current buffer
-        var match
-        var macrosFile
-        var texRootRex = /%(\s+)?!TEX macros(\s+)?=(\s+)?(.+)/g // Comment including the relative path to the macros file
-        var editor = atom.workspace.getActivePaneItem()
-        var file = editor.buffer.file
-        var path = file.path
+        let text = request.editor.getBuffer().getText() //By default we take macros from the current buffer
+        let matching_macros = find_macros(lu.strip_comments(text), escape_regex(macro_name_prefix))
 
+        const bufferFileFullPath = atom.workspace.getActivePaneItem().buffer.file.path // We the path to the buffer's file
+        const bufferFileDir = path.resolve(bufferFileFullPath,"..") // Remove the file from the path
+        const texRootRex = /%(\s+)?!TEX macros(\s+)?=(\s+)?(.+)/g // LaTeX comment including the path to the macros file
+
+        // We look for the varible containing the path to the macros file
+        let match
+        let macrosFile
         while(match = texRootRex.exec(request.editor.getBuffer().getText())) {
-          macrosFile = absolute(path,match[4])
+          macrosFile = path.resolve(bufferFileDir,match[4])
         }
+
+        // If the macros file is specified we look for macros and concatenate them to the ones defined in the curren file
         if (macrosFile != undefined) {
           try {
-            text = fs.readFileSync(macrosFile, 'utf-8');
-          } catch (e) {
+            text = fs.readFileSync(macrosFile, 'utf-8')
+            matching_macros = matching_macros.concat(find_macros(lu.strip_comments(text), escape_regex(macro_name_prefix)))
+          } catch (e) { // If the file specified cannot be read, we show an error message
             atom.notifications.addError('Macros file not found. Please, check the specified path.')
           }
         }
-        const matching_macros = find_macros(lu.strip_comments(text), escape_regex(macro_name_prefix))
 
         if (!matching_macros){
             return null
@@ -101,24 +107,6 @@ const snippet_from_macro_desc = function(macro_desc){
     // Due to [snippet idiosyncrasies](https://github.com/atom/snippets/issues/127),
     // don't forget to double our backslashes.
     return snippet.replace('\\', '\\\\')
-}
-
-// Simple function to compute the absolute path from the relative one and the
-// base
-function absolute(base, relative) {
-  var stack = base.split("/"),
-      parts = relative.split("/");
-  stack.pop(); // remove current file name (or empty string)
-  // (omit if "base" is the current folder without trailing slash)
-  for (var i=0; i<parts.length; i++) {
-    if (parts[i] == ".")
-    continue;
-    if (parts[i] == "..")
-    stack.pop();
-    else
-    stack.push(parts[i]);
-  }
-  return stack.join("/");
 }
 
 module.exports = {


### PR DESCRIPTION
Support to fetch macros from a separated file by specifying the relative path to it. The path needs to be included (in all files) as comment as follows:
`%!TEX macros = <path to macros file>`