### PR TITLE
Support other LaTeX grammar providers

### DIFF
--- a/lib/latexautocomplete.js
+++ b/lib/latexautocomplete.js
@@ -8,11 +8,11 @@ const macro_completer = require('./macros_autocompletion/macro_completer.js')
 const completed_editors = new Map()
 
 function complete_if_latex(editor){
-    if (editor.getGrammar().name == 'LaTeX' && !completed_editors.has(editor)){
+    if (editor.getGrammar().scopeName === 'text.tex.latex' && !completed_editors.has(editor)){
         const comp =  new env_completer.Completer(editor, atom.config.get('latex-autocomplete.addItemToListEnvironments'))
         completed_editors.set(editor, comp)
         comp.on_destroyed = (() => completed_editors.delete(editor))
-    } else if (editor.getGrammar().name != 'LaTeX' && completed_editors.has(editor)){
+    } else if (editor.getGrammar().scopeName !== 'text.tex.latex' && completed_editors.has(editor)){
         completed_editors.get(editor).destroy()
     }
 }


### PR DESCRIPTION
The original checked if the grammar `name` equalled `LaTeX`, which does not follow any sort of regulation and cannot be expected to be true for all LaTeX language providers.

The proposed change replaces the check with `scopeName`, which is far more consistent across language packages; if a grammar is for LaTeX, the scope name will be `text.tex.latex`. I also changed the equality to `===`, as the checking is between two strings and seems more appropriate.